### PR TITLE
Updating Api/Droplet with new getTotal() function

### DIFF
--- a/src/Api/Droplet.php
+++ b/src/Api/Droplet.php
@@ -49,6 +49,18 @@ class Droplet extends AbstractApi
     }
 
     /**
+     * @return $total
+     */
+    public function getTotal()
+    {
+        $url = sprintf('%s/droplets?per_page=1&page=1', $this->endpoint);
+        $droplets = json_decode($this->adapter->get($url));
+        $total = $droplets->meta->total;
+        
+        return $total;
+    }
+
+    /**
      * @param int $id
      *
      * @return DropletEntity[]


### PR DESCRIPTION
Purpose of this new function is to provide a starting point for paginating Droplet requests.

This PR implements a new function for returning the total amount of **Droplets**. This is an initial enhancement based on #29 . Implementation is basic and is as follows:

1. Make API request for `/droplets` with `$perPage = 1` and `$page = 1` (we only need 1 result to get the `meta` object)
2. Get `meta->total` for Droplet Total
3. Return `$total`

Can be used like

```
        // Total Droplets from API
        $total    = DigitalOcean::droplet()->getTotal();
        
        // How many times we should iterate $page
        $pages    = ceil($total / $perPage);

        for ($i = 1; $i <= $pages; $i++) {
            $request = DigitalOcean::droplet()->getAll($perPage, $i);
            foreach ($request as $item) {
                array_push($droplets, $item);
            }
        }
```