### PR TITLE
Add filesystem_type and filesystem_label when creating volumes

### DIFF
--- a/spec/DigitalOceanV2/Api/VolumeSpec.php
+++ b/spec/DigitalOceanV2/Api/VolumeSpec.php
@@ -407,6 +407,110 @@ EOT;
     /**
      * @param \DigitalOceanV2\Adapter\AdapterInterface $adapter
      */
+    public function it_send_payload_with_filesystem_type($adapter)
+    {
+        $response = <<<'EOT'
+            {
+                "volume": {
+                    "id": "506f78a4-e098-11e5-ad9f-000f53306ae1",
+                    "region": {
+                    "name": "New York 1",
+                    "slug": "nyc1",
+                    "sizes": [
+                        "512mb",
+                        "1gb",
+                        "2gb",
+                        "4gb",
+                        "8gb",
+                        "16gb",
+                        "32gb",
+                        "48gb",
+                        "64gb"
+                    ],
+                    "features": [
+                        "private_networking",
+                        "backups",
+                        "ipv6",
+                        "metadata"
+                    ],
+                    "available": true
+                    },
+                    "droplet_ids": [
+
+                    ],
+                    "name": "example",
+                    "description": "Block store for examples",
+                    "size_gigabytes": 10,
+                    "created_at": "2016-03-02T17:00:49Z"
+                }
+            }       
+EOT;
+
+        $adapter
+            ->post(
+                'https://api.digitalocean.com/v2/volumes',
+                ['name' => 'example', 'description' => 'Block store for examples snapshot id', 'size_gigabytes' => '10', 'region' => 'nyc1', 'filesystem_type' => 'ext4']
+            )
+            ->shouldBeCalled()->willReturn($response);
+
+        $volume = $this->create('example', 'Block store for examples snapshot id', 10, 'nyc1', null, 'ext4');
+    }
+
+    /**
+     * @param \DigitalOceanV2\Adapter\AdapterInterface $adapter
+     */
+    public function it_send_payload_with_filesystem_label($adapter)
+    {
+        $response = <<<'EOT'
+            {
+                "volume": {
+                    "id": "506f78a4-e098-11e5-ad9f-000f53306ae1",
+                    "region": {
+                    "name": "New York 1",
+                    "slug": "nyc1",
+                    "sizes": [
+                        "512mb",
+                        "1gb",
+                        "2gb",
+                        "4gb",
+                        "8gb",
+                        "16gb",
+                        "32gb",
+                        "48gb",
+                        "64gb"
+                    ],
+                    "features": [
+                        "private_networking",
+                        "backups",
+                        "ipv6",
+                        "metadata"
+                    ],
+                    "available": true
+                    },
+                    "droplet_ids": [
+
+                    ],
+                    "name": "example",
+                    "description": "Block store for examples",
+                    "size_gigabytes": 10,
+                    "created_at": "2016-03-02T17:00:49Z"
+                }
+            }       
+EOT;
+
+        $adapter
+            ->post(
+                'https://api.digitalocean.com/v2/volumes',
+                ['name' => 'example', 'description' => 'Block store for examples snapshot id', 'size_gigabytes' => '10', 'region' => 'nyc1', 'filesystem_label' => 'My filesystem!']
+            )
+            ->shouldBeCalled()->willReturn($response);
+
+        $volume = $this->create('example', 'Block store for examples snapshot id', 10, 'nyc1', null, null, 'My filesystem!');
+    }
+
+    /**
+     * @param \DigitalOceanV2\Adapter\AdapterInterface $adapter
+     */
     public function it_throws_an_http_exception_if_not_possible_to_create_a_volume($adapter)
     {
         $adapter
@@ -840,7 +944,8 @@ EOT;
         }
 EOT;
         $adapter
-            ->post('https://api.digitalocean.com/v2/volumes/506f78a4-e098-11e5-ad9f-000f53306ae1/snapshots',
+            ->post(
+                'https://api.digitalocean.com/v2/volumes/506f78a4-e098-11e5-ad9f-000f53306ae1/snapshots',
                 ['name' => 'snapshot1-volume']
             )
             ->willReturn($response);

--- a/src/Api/Volume.php
+++ b/src/Api/Volume.php
@@ -100,10 +100,12 @@ class Volume extends AbstractApi
      * @param string $sizeInGigabytes The size of the Block Storage volume in GiB
      * @param string $regionSlug      The region where the Block Storage volume will be created
      * @param string $snapshotId      The unique identifier for the volume snapshot from which to create the volume. Should not be specified with a region_id.
+     * @param string $filesystemType  The name of the filesystem type to be used on the volume.
+     * @param string $filesystemLabel The label to be applied to the filesystem.
      *
      * @return VolumeEntity
      */
-    public function create($name, $description, $sizeInGigabytes, $regionSlug, $snapshotId = null)
+    public function create($name, $description, $sizeInGigabytes, $regionSlug, $snapshotId = null, $filesystemType = null, $filesystemLabel = null)
     {
         $data = [
             'size_gigabytes' => $sizeInGigabytes,
@@ -112,8 +114,14 @@ class Volume extends AbstractApi
             'region' => $regionSlug,
         ];
 
-        if($snapshotId !== null) {
+        if ($snapshotId !== null) {
             $data['snapshot_id'] = $snapshotId;
+        }
+        if ($filesystemType !== null) {
+            $data['filesystem_type'] = $filesystemType;
+        }
+        if ($filesystemLabel !== null) {
+            $data['filesystem_label'] = $filesystemLabel;
         }
 
         $volume = $this->adapter->post(sprintf('%s/volumes', $this->endpoint), $data);


### PR DESCRIPTION
Add support for `filesystem_type` and `filesystem_label` when creating volumes, which should allow volumes to be automatically mounted.