### PR TITLE
Added support for newer properties for volumes

### DIFF
--- a/src/Entity/Volume.php
+++ b/src/Entity/Volume.php
@@ -52,6 +52,21 @@ final class Volume extends AbstractEntity
     public $createdAt;
 
     /**
+     * @var string
+     */
+    public $filesystemType;
+
+    /**
+     * @var string
+     */
+    public $filesystemLabel;
+
+    /**
+     * @var Tags[]
+     */
+    public $tags = [];
+
+    /**
      * @param array $parameters
      */
     public function build(array $parameters)


### PR DESCRIPTION
This adds a couple of missing properties to the Volume entity, those specific properties are `filesystem_type`, `filesystem_label`, and `tags`. Perhaps this is best as part of #240 since that pull adds support for setting them but not reading them from the api.